### PR TITLE
Small improvements for ntrtl.h (#512)

### DIFF
--- a/phnt/include/ntrtl.h
+++ b/phnt/include/ntrtl.h
@@ -5879,6 +5879,14 @@ RtlReplaceSidInSd(
 NTSYSAPI
 NTSTATUS
 NTAPI
+RtlLengthSidAsUnicodeString(
+    _In_ PSID Sid,
+    _Out_ PULONG StringLength
+    );
+
+NTSYSAPI
+NTSTATUS
+NTAPI
 RtlConvertSidToUnicodeString(
     _Inout_ PUNICODE_STRING UnicodeString,
     _In_ PSID Sid,
@@ -7682,7 +7690,7 @@ RtlQueryTokenHostIdAsUlong64(
 
 // rev
 NTSYSAPI
-NTSTATUS
+BOOLEAN
 NTAPI
 RtlIsParentOfChildAppContainer(
     _In_ PSID ParentAppContainerSid,


### PR DESCRIPTION
* Fix return type of RtlIsParentOfChildAppContainer

* Add RtlLengthSidAsUnicodeString